### PR TITLE
Fix tag workflow and add release creation

### DIFF
--- a/.github/workflows/updateTag.yml
+++ b/.github/workflows/updateTag.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     types: [closed]
     branches:
-      - release/*
+      - release
 
 permissions:
   contents: write
@@ -15,10 +15,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v6
-      with:
-        fetch-depth: 0
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: Get latest tag
         run: |
@@ -36,3 +36,14 @@ jobs:
           git config user.email "github-actions@github.com"
           git tag -a "$NEW_TAG" -m "Release $NEW_TAG"
           git push origin "$NEW_TAG"
+
+      - name: Create GitHub release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ env.NEW_TAG }}
+          release_name: Release ${{ env.NEW_TAG }}
+          body: "Automated release for ${{ github.event.pull_request.base.ref }}"
+          draft: false
+          prerelease: false


### PR DESCRIPTION
## Summary
- fix indentation of updateTag workflow steps so tagging runs
- generate a new tag on merged release pull requests
- create a GitHub Release using the new tag
- trigger the workflow for PRs into the `release` branch (instead of `release/*`)

## Testing
- not run (workflow change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c2b5f4e188320a586de004c1a3ae3)