### PR TITLE
Include worker order project in web Dockerfile

### DIFF
--- a/EvangelionERPV2.Web/Dockerfile
+++ b/EvangelionERPV2.Web/Dockerfile
@@ -10,6 +10,7 @@ EXPOSE 8081
 FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 ARG BUILD_CONFIGURATION=Release
 WORKDIR /src
+COPY ["EvangelionERPV2.sln", "./"]
 COPY ["EvangelionERPV2.Web/EvangelionERPV2.Web.csproj", "EvangelionERPV2.Web/"]
 COPY ["EvangelionERPV2.Customer.Application/EvangelionERPV2.CustomerModule.Application.csproj", "EvangelionERPV2.Customer.Application/"]
 COPY ["EvangelionERPV2.Customer.Domain/EvangelionERPV2.CustomerModule.Domain.csproj", "EvangelionERPV2.Customer.Domain/"]
@@ -32,7 +33,7 @@ COPY ["EvangelionERPV2.User.Domain/EvangelionERPV2.UserModule.Domain.csproj", "E
 COPY ["EvangelionERPV2.User.Infra/EvangelionERPV2.UserModule.Infra.csproj", "EvangelionERPV2.User.Infra/"]
 COPY ["EvangelionERPV2.Worker.Order/EvangelionERPV2.Worker.Order.csproj", "EvangelionERPV2.Worker.Order/"]
 COPY ["EvangelionERPV2.Worker.Email/EvangelionERPV2.Worker.Email.csproj", "EvangelionERPV2.Worker.Email/"]
-RUN dotnet restore "./EvangelionERPV2.Web/EvangelionERPV2.Web.csproj"
+RUN dotnet restore "EvangelionERPV2.sln"
 COPY . .
 WORKDIR "/src/EvangelionERPV2.Web"
 RUN dotnet build "./EvangelionERPV2.Web.csproj" -c $BUILD_CONFIGURATION -o /app/build

--- a/EvangelionERPV2.Web/Dockerfile
+++ b/EvangelionERPV2.Web/Dockerfile
@@ -30,8 +30,8 @@ COPY ["EvangelionERPV2.Enterprise.Application/EvangelionERPV2.EnterpriseModule.A
 COPY ["EvangelionERPV2.User.Application/EvangelionERPV2.UserModule.Application.csproj", "EvangelionERPV2.User.Application/"]
 COPY ["EvangelionERPV2.User.Domain/EvangelionERPV2.UserModule.Domain.csproj", "EvangelionERPV2.User.Domain/"]
 COPY ["EvangelionERPV2.User.Infra/EvangelionERPV2.UserModule.Infra.csproj", "EvangelionERPV2.User.Infra/"]
-COPY ["EvangelionERPV2.Worker.Email/EvangelionERPV2.Worker.Email.csproj", "EvangelionERPV2.Worker.Email/"]
 COPY ["EvangelionERPV2.Worker.Order/EvangelionERPV2.Worker.Order.csproj", "EvangelionERPV2.Worker.Order/"]
+COPY ["EvangelionERPV2.Worker.Email/EvangelionERPV2.Worker.Email.csproj", "EvangelionERPV2.Worker.Email/"]
 RUN dotnet restore "./EvangelionERPV2.Web/EvangelionERPV2.Web.csproj"
 COPY . .
 WORKDIR "/src/EvangelionERPV2.Web"


### PR DESCRIPTION
## Summary
- copy the Worker.Order project file into the Docker build context so restore succeeds when both workers exist

## Testing
- not run (CI only)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6950606422f483209bb5d88bcf80a31c)