### PR TITLE
Simplify Docker build context handling

### DIFF
--- a/EvangelionERPV2.Web/Dockerfile
+++ b/EvangelionERPV2.Web/Dockerfile
@@ -11,32 +11,8 @@ FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 ARG BUILD_CONFIGURATION=Release
 WORKDIR /src
 
-# Copy solution and project files first for better restore caching and to ensure all dependencies are available.
-COPY ["EvangelionERPV2.sln", "."]
-COPY ["EvangelionERPV2.Web/EvangelionERPV2.Web.csproj", "EvangelionERPV2.Web/"]
-COPY ["EvangelionERPV2.Customer.Application/EvangelionERPV2.CustomerModule.Application.csproj", "EvangelionERPV2.Customer.Application/"]
-COPY ["EvangelionERPV2.Customer.Domain/EvangelionERPV2.CustomerModule.Domain.csproj", "EvangelionERPV2.Customer.Domain/"]
-COPY ["EvangelionERPV2.Customer.Infra/EvangelionERPV2.CustomerModule.Infra.csproj", "EvangelionERPV2.Customer.Infra/"]
-COPY ["EvangelionERPV2.Email.Application/EvangelionERPV2.EmailModule.Application.csproj", "EvangelionERPV2.Email.Application/"]
-COPY ["EvangelionERPV2.Email.Domain/EvangelionERPV2.EmailModule.Domain.csproj", "EvangelionERPV2.Email.Domain/"]
-COPY ["EvangelionERPV2.Email.Infra/EvangelionERPV2.EmailModule.Infra.csproj", "EvangelionERPV2.Email.Infra/"]
-COPY ["EvangelionERPV2.Enterprise.Application/EvangelionERPV2.EnterpriseModule.Application.csproj", "EvangelionERPV2.Enterprise.Application/"]
-COPY ["EvangelionERPV2.Enterprise.Domain/EvangelionERPV2.EnterpriseModule.Domain.csproj", "EvangelionERPV2.Enterprise.Domain/"]
-COPY ["EvangelionERPV2.Enterprise.Infra/EvangelionERPV2.EnterpriseModule.Infra.csproj", "EvangelionERPV2.Enterprise.Infra/"]
-COPY ["EvangelionERPV2.Order.Application/EvangelionERPV2.OrderModule.Application.csproj", "EvangelionERPV2.Order.Application/"]
-COPY ["EvangelionERPV2.Order.Domain/EvangelionERPV2.OrderModule.Domain.csproj", "EvangelionERPV2.Order.Domain/"]
-COPY ["EvangelionERPV2.Order.Infra/EvangelionERPV2.OrderModule.Infra.csproj", "EvangelionERPV2.Order.Infra/"]
-COPY ["EvangelionERPV2.Product.Application/EvangelionERPV2.ProductModule.Application.csproj", "EvangelionERPV2.Product.Application/"]
-COPY ["EvangelionERPV2.Product.Domain/EvangelionERPV2.ProductModule.Domain.csproj", "EvangelionERPV2.Product.Domain/"]
-COPY ["EvangelionERPV2.Product.Infra/EvangelionERPV2.ProductModule.Infra.csproj", "EvangelionERPV2.Product.Infra/"]
-COPY ["EvangelionERPV2.Shared/EvangelionERPV2.Shared.csproj", "EvangelionERPV2.Shared/"]
-COPY ["EvangelionERPV2.User.Application/EvangelionERPV2.UserModule.Application.csproj", "EvangelionERPV2.User.Application/"]
-COPY ["EvangelionERPV2.User.Domain/EvangelionERPV2.UserModule.Domain.csproj", "EvangelionERPV2.User.Domain/"]
-COPY ["EvangelionERPV2.User.Infra/EvangelionERPV2.UserModule.Infra.csproj", "EvangelionERPV2.User.Infra/"]
-COPY ["EvangelionERPV2.Worker.Email/EvangelionERPV2.Worker.Email.csproj", "EvangelionERPV2.Worker.Email/"]
-COPY ["EvangelionERPV2.Worker.Order/EvangelionERPV2.Worker.Order.csproj", "EvangelionERPV2.Worker.Order/"]
-
-# Copy the rest of the source once project files are in place.
+# Copy the entire repository so dotnet restore can resolve all project references
+# even when the build context is set from the EvangelionERPV2.Web folder.
 COPY . .
 RUN dotnet restore "EvangelionERPV2.sln"
 


### PR DESCRIPTION
## Summary
- copy the full repository before restore to ensure all project references are available
- simplify Dockerfile by removing per-project copy statements that could fail when the build context omitted sibling folders

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952bf8bf4fc8320be04367f2bd9995b)