### PR TITLE
Add Docker Hub login to CI workflow

### DIFF
--- a/.github/workflows/buildPushDeploy.yml
+++ b/.github/workflows/buildPushDeploy.yml
@@ -25,6 +25,12 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v5
         with:


### PR DESCRIPTION
## Summary
- add Docker Hub login to CI workflow so pushing images succeeds

## Testing
- not run (CI only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69531f137bdc83209523a867373ad332)