### PR TITLE
Change development port to 5002 to avoid conflicts

### DIFF
--- a/EvangelionERPV2.Web/Properties/launchSettings.json
+++ b/EvangelionERPV2.Web/Properties/launchSettings.json
@@ -8,7 +8,7 @@
                 "ASPNETCORE_ENVIRONMENT": "Development"
             },
             "dotnetRunMessages": true,
-            "applicationUrl": "http://localhost:5000"
+            "applicationUrl": "http://localhost:5002"
         },
         "EvangelionERPV2.Web (Production)": {
             "commandName": "Project",

--- a/EvangelionERPV2.Web/appsettings.Development.json
+++ b/EvangelionERPV2.Web/appsettings.Development.json
@@ -35,7 +35,7 @@
         "TokenKey": "evangelion/dev/encryptiontokenkey"
     },
     "HttpConfig": {
-        "DefaultApiUrl": "http://localhost:5000/api/v1"
+        "DefaultApiUrl": "http://localhost:5002/api/v1"
     },
     "AWSSettings": {
         "SecretName": "AWSCredentials",

--- a/EvangelionERPV2.Worker.Email/appsettings.Development.json
+++ b/EvangelionERPV2.Worker.Email/appsettings.Development.json
@@ -21,9 +21,9 @@
   "Encryption": {
     "Key": "evangelion/dev/encryptionkey:key"
   },
-  "HttpConfig": {
-    "DefaultApiUrl": "http://localhost:5000/api/v1"
-  },
+    "HttpConfig": {
+        "DefaultApiUrl": "http://localhost:5002/api/v1"
+    },
   "AWSSettings": {
     "SecretName": "AWSCredentials",
     "BucketProducttName": "evangelionerpv2images"

--- a/EvangelionERPV2.Worker.Order/appsettings.Development.json
+++ b/EvangelionERPV2.Worker.Order/appsettings.Development.json
@@ -21,9 +21,9 @@
   "Encryption": {
     "Key": "evangelion/dev/encryptionkey:key"
   },
-  "HttpConfig": {
-    "DefaultApiUrl": "http://localhost:5000/api/v1"
-  },
+    "HttpConfig": {
+        "DefaultApiUrl": "http://localhost:5002/api/v1"
+    },
   "AWSSettings": {
     "SecretName": "AWSCredentials",
     "BucketProducttName": "evangelionerpv2images"


### PR DESCRIPTION
## Summary
- move the Web development launch profile to port 5002 to avoid conflicts on localhost:5000
- align development DefaultApiUrl values for the Web app and background workers with the new port

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6954256330ac8320877afd27cb3dbfdc)