### PR TITLE
feat: add cash-flow forecast and scenario simulation APIs

### DIFF
--- a/EvangelionERPV2.Bills.Application/DI/BillsIoC.cs
+++ b/EvangelionERPV2.Bills.Application/DI/BillsIoC.cs
@@ -55,6 +55,8 @@ namespace EvangelionERPV2.BillsModule.Application.DI
 
                 #region Services
                 services.AddScoped(typeof(IBillsService<Bill>), typeof(BillsService));
+                services.AddScoped<IPayableBillService, PayableBillService>();
+                services.AddScoped<ICashFlowForecastService, CashFlowForecastService>();
                 #endregion
 
                 services.AddScoped(typeof(EvangelionERPV2.Shared.Repositories.IUnitOfWork<AppDbContext>), typeof(EvangelionERPV2.Shared.Repositories.UnitOfWork<AppDbContext>));

--- a/EvangelionERPV2.Bills.Application/Interface/ICashFlowForecastService.cs
+++ b/EvangelionERPV2.Bills.Application/Interface/ICashFlowForecastService.cs
@@ -1,0 +1,10 @@
+using EvangelionERPV2.Shared.DTOs;
+
+namespace EvangelionERPV2.BillsModule.Application.Interface
+{
+    public interface ICashFlowForecastService
+    {
+        Task<CashFlowForecastDTO> GetForecastAsync(Guid enterpriseId, int horizonInDays, double currentBalance);
+        Task<IEnumerable<SimulationResultDTO>> RunSimulationAsync(Guid enterpriseId, Guid userId, RunSimulationRequestDTO request);
+    }
+}

--- a/EvangelionERPV2.Bills.Application/Interface/IPayableBillService.cs
+++ b/EvangelionERPV2.Bills.Application/Interface/IPayableBillService.cs
@@ -1,0 +1,13 @@
+using EvangelionERPV2.Shared.Entities;
+
+namespace EvangelionERPV2.BillsModule.Application.Interface
+{
+    public interface IPayableBillService
+    {
+        Task<PayableBill> CreateAsync(PayableBill payableBill);
+        Task<IEnumerable<PayableBill>> GetByEnterpriseIdAsync(Guid enterpriseId, int? pageNumber = null, int? pageSize = null);
+        Task<PayableBill?> GetByIdAsync(Guid id, Guid enterpriseId);
+        Task<PayableBill> UpdateAsync(PayableBill payableBill, Guid enterpriseId);
+        Task<PayableBill> DeleteAsync(Guid id, Guid enterpriseId);
+    }
+}

--- a/EvangelionERPV2.Bills.Application/Services/CashFlowForecastService.cs
+++ b/EvangelionERPV2.Bills.Application/Services/CashFlowForecastService.cs
@@ -1,0 +1,127 @@
+using System.Text.Json;
+using EvangelionERPV2.BillsModule.Application.Interface;
+using EvangelionERPV2.Shared.DTOs;
+using EvangelionERPV2.Shared.Entities;
+using EvangelionERPV2.Shared.Repositories;
+
+namespace EvangelionERPV2.BillsModule.Application.Services
+{
+    public class CashFlowForecastService : ICashFlowForecastService
+    {
+        private readonly IRepository<Order> _orderRepository;
+        private readonly IRepository<PayableBill> _payableBillRepository;
+        private readonly IRepository<ForecastSimulationLog> _simulationLogRepository;
+
+        public CashFlowForecastService(
+            IRepository<Order> orderRepository,
+            IRepository<PayableBill> payableBillRepository,
+            IRepository<ForecastSimulationLog> simulationLogRepository)
+        {
+            _orderRepository = orderRepository;
+            _payableBillRepository = payableBillRepository;
+            _simulationLogRepository = simulationLogRepository;
+        }
+
+        public async Task<CashFlowForecastDTO> GetForecastAsync(Guid enterpriseId, int horizonInDays, double currentBalance)
+        {
+            return await BuildForecastAsync(enterpriseId, horizonInDays, currentBalance, 0, 1);
+        }
+
+        public async Task<IEnumerable<SimulationResultDTO>> RunSimulationAsync(Guid enterpriseId, Guid userId, RunSimulationRequestDTO request)
+        {
+            var scenarios = request.Scenarios?.ToList() ?? [];
+            if (scenarios.Count < 2)
+                throw new ArgumentException("At least two scenarios are required.");
+
+            var baseline = await BuildForecastAsync(enterpriseId, request.HorizonInDays, request.CurrentBalance, 0, 1);
+            var baselineFinalBalance = baseline.FinalProjectedBalance;
+            var results = new List<SimulationResultDTO>();
+
+            foreach (var scenario in scenarios)
+            {
+                var simulation = await BuildForecastAsync(
+                    enterpriseId,
+                    request.HorizonInDays,
+                    request.CurrentBalance,
+                    scenario.ReceivableDelayInDays,
+                    scenario.PayableMultiplier);
+
+                var riskDays = simulation.DailyProjection.Where(x => x.IsRiskDay).Select(x => x.Date.Date).ToList();
+                results.Add(new SimulationResultDTO
+                {
+                    ScenarioName = scenario.ScenarioName,
+                    FinalProjectedBalance = simulation.FinalProjectedBalance,
+                    Impact = simulation.FinalProjectedBalance - baselineFinalBalance,
+                    RiskDays = riskDays
+                });
+
+                await _simulationLogRepository.CreateAsync(new ForecastSimulationLog
+                {
+                    Id = Guid.NewGuid(),
+                    EnterpriseId = enterpriseId,
+                    UserId = userId,
+                    ExecutedAt = DateTime.UtcNow,
+                    ScenarioName = scenario.ScenarioName,
+                    HorizonInDays = request.HorizonInDays,
+                    FinalProjectedBalance = simulation.FinalProjectedBalance,
+                    InputsJson = JsonSerializer.Serialize(scenario),
+                    CreatedAt = DateTime.UtcNow,
+                    UpdatedAt = DateTime.UtcNow,
+                    IsActive = true
+                });
+            }
+
+            await _simulationLogRepository.CommitAsync();
+            return results;
+        }
+
+        private async Task<CashFlowForecastDTO> BuildForecastAsync(Guid enterpriseId, int horizonInDays, double currentBalance, int receivableDelayInDays, double payableMultiplier)
+        {
+            var today = DateTime.UtcNow.Date;
+            var endDate = today.AddDays(horizonInDays);
+
+            var orders = (await _orderRepository.GetAllAsync(x => x.EnterpriseId == enterpriseId && x.IsActive == true)).ToList();
+            var receivables = orders
+                .Select(x => new
+                {
+                    Date = ((x.Payday ?? x.PaymentScheduledDate).Date).AddDays(receivableDelayInDays),
+                    Amount = x.TotalValue
+                })
+                .Where(x => x.Date >= today && x.Date <= endDate)
+                .GroupBy(x => x.Date)
+                .ToDictionary(x => x.Key, x => x.Sum(y => y.Amount));
+
+            var payables = (await _payableBillRepository.GetAllAsync(x => x.EnterpriseId == enterpriseId && x.IsActive == true && !x.IsPaid))
+                .Where(x => x.DueDate.Date >= today && x.DueDate.Date <= endDate)
+                .GroupBy(x => x.DueDate.Date)
+                .ToDictionary(x => x.Key, x => x.Sum(y => y.Amount * payableMultiplier));
+
+            var projection = new List<CashFlowForecastDayDTO>();
+            var runningBalance = currentBalance;
+
+            for (var date = today; date <= endDate; date = date.AddDays(1))
+            {
+                receivables.TryGetValue(date, out var dayReceivable);
+                payables.TryGetValue(date, out var dayPayable);
+                runningBalance += dayReceivable - dayPayable;
+
+                projection.Add(new CashFlowForecastDayDTO
+                {
+                    Date = date,
+                    AccountsReceivable = dayReceivable,
+                    AccountsPayable = dayPayable,
+                    ProjectedBalance = runningBalance,
+                    IsRiskDay = runningBalance < 0
+                });
+            }
+
+            return new CashFlowForecastDTO
+            {
+                HorizonInDays = horizonInDays,
+                CurrentBalance = currentBalance,
+                FinalProjectedBalance = runningBalance,
+                DailyProjection = projection
+            };
+        }
+    }
+}

--- a/EvangelionERPV2.Bills.Application/Services/PayableBillService.cs
+++ b/EvangelionERPV2.Bills.Application/Services/PayableBillService.cs
@@ -1,0 +1,74 @@
+using EvangelionERPV2.BillsModule.Application.Interface;
+using EvangelionERPV2.Shared.Entities;
+using EvangelionERPV2.Shared.Exceptions;
+using EvangelionERPV2.Shared.Repositories;
+
+namespace EvangelionERPV2.BillsModule.Application.Services
+{
+    public class PayableBillService : IPayableBillService
+    {
+        private readonly IRepository<PayableBill> _payableBillRepository;
+
+        public PayableBillService(IRepository<PayableBill> payableBillRepository)
+        {
+            _payableBillRepository = payableBillRepository;
+        }
+
+        public async Task<PayableBill> CreateAsync(PayableBill payableBill)
+        {
+            payableBill.Id = payableBill.Id == Guid.Empty ? Guid.NewGuid() : payableBill.Id;
+            payableBill.CreatedAt = DateTime.UtcNow;
+            payableBill.UpdatedAt = DateTime.UtcNow;
+            payableBill.IsActive = true;
+
+            var created = await _payableBillRepository.CreateAsync(payableBill);
+            await _payableBillRepository.CommitAsync();
+            return created;
+        }
+
+        public async Task<IEnumerable<PayableBill>> GetByEnterpriseIdAsync(Guid enterpriseId, int? pageNumber = null, int? pageSize = null)
+        {
+            return await _payableBillRepository.GetAllAsync(pageNumber, pageSize, x => x.EnterpriseId == enterpriseId && x.IsActive == true);
+        }
+
+        public async Task<PayableBill?> GetByIdAsync(Guid id, Guid enterpriseId)
+        {
+            var bill = await _payableBillRepository.GetByIdAsync(id);
+            if (bill == null || bill.EnterpriseId != enterpriseId || bill.IsActive != true)
+                return null;
+
+            return bill;
+        }
+
+        public async Task<PayableBill> UpdateAsync(PayableBill payableBill, Guid enterpriseId)
+        {
+            var existing = await _payableBillRepository.GetByIdAsync(payableBill.Id);
+            if (existing == null || existing.EnterpriseId != enterpriseId || existing.IsActive != true)
+                throw new NotFoundDatabaseException($"{nameof(PayableBill)} was not found in database.");
+
+            existing.Description = payableBill.Description;
+            existing.DueDate = payableBill.DueDate;
+            existing.PaidAt = payableBill.PaidAt;
+            existing.Amount = payableBill.Amount;
+            existing.IsPaid = payableBill.IsPaid;
+            existing.UpdatedAt = DateTime.UtcNow;
+
+            _payableBillRepository.Update(existing);
+            await _payableBillRepository.CommitAsync();
+            return existing;
+        }
+
+        public async Task<PayableBill> DeleteAsync(Guid id, Guid enterpriseId)
+        {
+            var existing = await _payableBillRepository.GetByIdAsync(id);
+            if (existing == null || existing.EnterpriseId != enterpriseId || existing.IsActive != true)
+                throw new NotFoundDatabaseException($"{nameof(PayableBill)} was not found in database.");
+
+            existing.IsActive = false;
+            existing.UpdatedAt = DateTime.UtcNow;
+            _payableBillRepository.Update(existing);
+            await _payableBillRepository.CommitAsync();
+            return existing;
+        }
+    }
+}

--- a/EvangelionERPV2.BillsModule.Test/Bills/CashFlowForecastServiceTests.cs
+++ b/EvangelionERPV2.BillsModule.Test/Bills/CashFlowForecastServiceTests.cs
@@ -1,0 +1,63 @@
+using EvangelionERPV2.BillsModule.Application.Services;
+using EvangelionERPV2.Shared.DTOs;
+using EvangelionERPV2.Shared.Entities;
+using EvangelionERPV2.Shared.Repositories;
+using Moq;
+
+namespace EvangelionERPV2.BillsModule.Test
+{
+    public class CashFlowForecastServiceTests
+    {
+        [Fact]
+        public async Task GetForecastAsync_ShouldCombineReceivablesAndPayablesAndFlagRiskDays()
+        {
+            var enterpriseId = Guid.NewGuid();
+            var today = DateTime.UtcNow.Date;
+
+            var orders = new List<Order>
+            {
+                new() { EnterpriseId = enterpriseId, PaymentScheduledDate = today.AddDays(1), TotalValue = 100, IsActive = true },
+                new() { EnterpriseId = enterpriseId, PaymentScheduledDate = today.AddDays(3), TotalValue = 50, IsActive = true }
+            };
+
+            var payables = new List<PayableBill>
+            {
+                new() { EnterpriseId = enterpriseId, DueDate = today.AddDays(2), Amount = 250, IsPaid = false, IsActive = true }
+            };
+
+            var orderRepo = new Mock<IRepository<Order>>();
+            orderRepo.Setup(x => x.GetAllAsync(It.IsAny<Func<Order, bool>>())).ReturnsAsync((Func<Order, bool>? f) => orders.Where(f!).ToList());
+
+            var payableRepo = new Mock<IRepository<PayableBill>>();
+            payableRepo.Setup(x => x.GetAllAsync(It.IsAny<Func<PayableBill, bool>>())).ReturnsAsync((Func<PayableBill, bool>? f) => payables.Where(f!).ToList());
+
+            var logRepo = new Mock<IRepository<ForecastSimulationLog>>();
+            var service = new CashFlowForecastService(orderRepo.Object, payableRepo.Object, logRepo.Object);
+
+            var result = await service.GetForecastAsync(enterpriseId, 30, 100);
+
+            Assert.Equal(0, result.FinalProjectedBalance, 2);
+            Assert.Contains(result.DailyProjection, x => x.Date == today.AddDays(2) && x.IsRiskDay);
+        }
+
+        [Fact]
+        public async Task RunSimulationAsync_WithLessThanTwoScenarios_ShouldThrow()
+        {
+            var orderRepo = new Mock<IRepository<Order>>();
+            orderRepo.Setup(x => x.GetAllAsync(It.IsAny<Func<Order, bool>>())).ReturnsAsync(new List<Order>());
+
+            var payableRepo = new Mock<IRepository<PayableBill>>();
+            payableRepo.Setup(x => x.GetAllAsync(It.IsAny<Func<PayableBill, bool>>())).ReturnsAsync(new List<PayableBill>());
+
+            var logRepo = new Mock<IRepository<ForecastSimulationLog>>();
+            var service = new CashFlowForecastService(orderRepo.Object, payableRepo.Object, logRepo.Object);
+
+            await Assert.ThrowsAsync<ArgumentException>(() => service.RunSimulationAsync(Guid.NewGuid(), Guid.NewGuid(), new RunSimulationRequestDTO
+            {
+                HorizonInDays = 30,
+                CurrentBalance = 100,
+                Scenarios = [new ForecastSimulationScenarioDTO { ScenarioName = "A" }]
+            }));
+        }
+    }
+}

--- a/EvangelionERPV2.BillsModule.Test/Bills/PayableBillServiceTests.cs
+++ b/EvangelionERPV2.BillsModule.Test/Bills/PayableBillServiceTests.cs
@@ -1,0 +1,53 @@
+using EvangelionERPV2.BillsModule.Application.Services;
+using EvangelionERPV2.Shared.Entities;
+using EvangelionERPV2.Shared.Exceptions;
+using EvangelionERPV2.Shared.Repositories;
+using Moq;
+
+namespace EvangelionERPV2.BillsModule.Test
+{
+    public class PayableBillServiceTests
+    {
+        [Fact]
+        public async Task CreateAsync_ShouldSetAuditFieldsAndPersist()
+        {
+            var repo = new Mock<IRepository<PayableBill>>();
+            repo.Setup(x => x.CreateAsync(It.IsAny<PayableBill>())).ReturnsAsync((PayableBill x) => x);
+            var service = new PayableBillService(repo.Object);
+
+            var entity = new PayableBill { Description = "Rent", Amount = 1000, EnterpriseId = Guid.NewGuid() };
+            var result = await service.CreateAsync(entity);
+
+            Assert.NotEqual(Guid.Empty, result.Id);
+            Assert.True(result.IsActive);
+            repo.Verify(x => x.CommitAsync(It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task UpdateAsync_WhenNotFound_ShouldThrow()
+        {
+            var repo = new Mock<IRepository<PayableBill>>();
+            repo.Setup(x => x.GetByIdAsync(It.IsAny<Guid>())).ReturnsAsync((PayableBill?)null);
+            var service = new PayableBillService(repo.Object);
+
+            await Assert.ThrowsAsync<NotFoundDatabaseException>(() => service.UpdateAsync(new PayableBill { Id = Guid.NewGuid() }, Guid.NewGuid()));
+        }
+
+        [Fact]
+        public async Task DeleteAsync_WhenFound_ShouldSoftDelete()
+        {
+            var enterpriseId = Guid.NewGuid();
+            var entity = new PayableBill { Id = Guid.NewGuid(), EnterpriseId = enterpriseId, IsActive = true };
+
+            var repo = new Mock<IRepository<PayableBill>>();
+            repo.Setup(x => x.GetByIdAsync(entity.Id)).ReturnsAsync(entity);
+            var service = new PayableBillService(repo.Object);
+
+            var result = await service.DeleteAsync(entity.Id, enterpriseId);
+
+            Assert.False(result.IsActive);
+            repo.Verify(x => x.Update(It.IsAny<PayableBill>()), Times.Once);
+            repo.Verify(x => x.CommitAsync(It.IsAny<CancellationToken>()), Times.Once);
+        }
+    }
+}

--- a/EvangelionERPV2.Shared/Configs/MapperConfig.cs
+++ b/EvangelionERPV2.Shared/Configs/MapperConfig.cs
@@ -21,6 +21,7 @@ namespace EvangelionERPV2.Shared.Configs
                     .ForMember(dest => dest.CustomerName, opt => opt.MapFrom(src => src.Customer != null ? src.Customer.Name : null))
                     .ReverseMap();
                 config.CreateMap<Bill, BillDTO>().ReverseMap();
+                config.CreateMap<PayableBill, PayableBillDTO>().ReverseMap();
                 config.CreateMap<NFeDocument, NFeDocumentDTO>().ReverseMap();
                 config.CreateMap<Customer, CustomerDTO>().ReverseMap();
                 config.CreateMap<Product, ProductDTO>().ReverseMap();

--- a/EvangelionERPV2.Shared/Context/AppDbContext.cs
+++ b/EvangelionERPV2.Shared/Context/AppDbContext.cs
@@ -17,6 +17,8 @@ namespace EvangelionERPV2.Shared.Context
         public DbSet<Order> Order { get; set; }
         public DbSet<OrderedProduct> OrderedProduct { get; set; }
         public DbSet<Product> Product { get; set; }
+        public DbSet<PayableBill> PayableBill { get; set; }
+        public DbSet<ForecastSimulationLog> ForecastSimulationLog { get; set; }
         public DbSet<RefreshToken> RefreshToken { get; set; }
         public DbSet<User> User { get; set; }
 

--- a/EvangelionERPV2.Shared/DTOs/CashFlowForecastDTO.cs
+++ b/EvangelionERPV2.Shared/DTOs/CashFlowForecastDTO.cs
@@ -1,0 +1,41 @@
+namespace EvangelionERPV2.Shared.DTOs
+{
+    public class CashFlowForecastDayDTO
+    {
+        public DateTime Date { get; set; }
+        public double AccountsReceivable { get; set; }
+        public double AccountsPayable { get; set; }
+        public double ProjectedBalance { get; set; }
+        public bool IsRiskDay { get; set; }
+    }
+
+    public class CashFlowForecastDTO
+    {
+        public int HorizonInDays { get; set; }
+        public double CurrentBalance { get; set; }
+        public double FinalProjectedBalance { get; set; }
+        public IEnumerable<CashFlowForecastDayDTO> DailyProjection { get; set; } = [];
+    }
+
+    public class ForecastSimulationScenarioDTO
+    {
+        public string ScenarioName { get; set; } = string.Empty;
+        public int ReceivableDelayInDays { get; set; }
+        public double PayableMultiplier { get; set; } = 1;
+    }
+
+    public class RunSimulationRequestDTO
+    {
+        public int HorizonInDays { get; set; }
+        public double CurrentBalance { get; set; }
+        public IEnumerable<ForecastSimulationScenarioDTO> Scenarios { get; set; } = [];
+    }
+
+    public class SimulationResultDTO
+    {
+        public string ScenarioName { get; set; } = string.Empty;
+        public double FinalProjectedBalance { get; set; }
+        public double Impact { get; set; }
+        public IEnumerable<DateTime> RiskDays { get; set; } = [];
+    }
+}

--- a/EvangelionERPV2.Shared/DTOs/PayableBillDTO.cs
+++ b/EvangelionERPV2.Shared/DTOs/PayableBillDTO.cs
@@ -1,0 +1,12 @@
+namespace EvangelionERPV2.Shared.DTOs
+{
+    public class PayableBillDTO : BaseDTO
+    {
+        public string Description { get; set; } = string.Empty;
+        public DateTime DueDate { get; set; } = DateTime.UtcNow;
+        public DateTime? PaidAt { get; set; }
+        public double Amount { get; set; }
+        public bool IsPaid { get; set; }
+        public Guid EnterpriseId { get; set; }
+    }
+}

--- a/EvangelionERPV2.Shared/Entities/ForecastSimulationLog.cs
+++ b/EvangelionERPV2.Shared/Entities/ForecastSimulationLog.cs
@@ -1,0 +1,16 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace EvangelionERPV2.Shared.Entities
+{
+    [Index(nameof(EnterpriseId), nameof(ExecutedAt))]
+    public class ForecastSimulationLog : BaseEntity
+    {
+        public Guid EnterpriseId { get; set; }
+        public Guid UserId { get; set; }
+        public DateTime ExecutedAt { get; set; } = DateTime.UtcNow;
+        public string ScenarioName { get; set; } = string.Empty;
+        public int HorizonInDays { get; set; }
+        public double FinalProjectedBalance { get; set; }
+        public string InputsJson { get; set; } = string.Empty;
+    }
+}

--- a/EvangelionERPV2.Shared/Entities/PayableBill.cs
+++ b/EvangelionERPV2.Shared/Entities/PayableBill.cs
@@ -1,0 +1,20 @@
+using Microsoft.EntityFrameworkCore;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace EvangelionERPV2.Shared.Entities
+{
+    [Index(nameof(EnterpriseId), nameof(DueDate))]
+    [Table("PayableBill")]
+    public class PayableBill : BaseEntity
+    {
+        public string Description { get; set; } = string.Empty;
+        public DateTime DueDate { get; set; } = DateTime.UtcNow;
+        public DateTime? PaidAt { get; set; }
+        public double Amount { get; set; }
+        public bool IsPaid { get; set; }
+
+        [ForeignKey(nameof(Enterprise))]
+        public Guid EnterpriseId { get; set; }
+        public virtual Enterprise? Enterprise { get; set; }
+    }
+}

--- a/EvangelionERPV2.Web/Controllers/CashFlowForecastController.cs
+++ b/EvangelionERPV2.Web/Controllers/CashFlowForecastController.cs
@@ -1,0 +1,80 @@
+using System.Security.Claims;
+using EvangelionERPV2.BillsModule.Application.Interface;
+using EvangelionERPV2.Shared.DTOs;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Serilog;
+
+namespace EvangelionERPV2.Web.Controllers
+{
+    [Authorize]
+    [Route("api/v{version:apiVersion}/[controller]/[action]")]
+    [ApiVersion("1.0")]
+    public class CashFlowForecastController : Controller
+    {
+        private readonly ICashFlowForecastService _cashFlowForecastService;
+
+        public CashFlowForecastController(ICashFlowForecastService cashFlowForecastService)
+        {
+            _cashFlowForecastService = cashFlowForecastService;
+        }
+
+        [HttpGet("{horizonInDays}/{currentBalance}")]
+        public async Task<IActionResult> GetForecast(int horizonInDays, double currentBalance)
+        {
+            try
+            {
+                if (!TryGetEnterpriseId(out var enterpriseId))
+                    return Unauthorized();
+
+                if (horizonInDays is not (30 or 60 or 90))
+                    return BadRequest("Horizon must be 30, 60 or 90 days.");
+
+                var result = await _cashFlowForecastService.GetForecastAsync(enterpriseId, horizonInDays, currentBalance);
+                return Ok(result);
+            }
+            catch (Exception ex)
+            {
+                Log.Logger.Error("Error generating cashflow forecast", ex);
+                return Problem(ex.Message);
+            }
+        }
+
+        [HttpPost]
+        public async Task<IActionResult> RunSimulation([FromBody] RunSimulationRequestDTO request)
+        {
+            try
+            {
+                if (!TryGetEnterpriseId(out var enterpriseId))
+                    return Unauthorized();
+
+                if (!TryGetUserId(out var userId))
+                    return Unauthorized();
+
+                var simulationResult = await _cashFlowForecastService.RunSimulationAsync(enterpriseId, userId, request);
+                return Ok(simulationResult);
+            }
+            catch (ArgumentException ex)
+            {
+                return BadRequest(ex.Message);
+            }
+            catch (Exception ex)
+            {
+                Log.Logger.Error("Error running cashflow simulation", ex);
+                return Problem(ex.Message);
+            }
+        }
+
+        private bool TryGetEnterpriseId(out Guid enterpriseId)
+        {
+            var claimValue = User.FindFirst(ClaimTypes.GroupSid)?.Value;
+            return Guid.TryParse(claimValue, out enterpriseId) && enterpriseId != Guid.Empty;
+        }
+
+        private bool TryGetUserId(out Guid userId)
+        {
+            var claimValue = User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+            return Guid.TryParse(claimValue, out userId) && userId != Guid.Empty;
+        }
+    }
+}

--- a/EvangelionERPV2.Web/Controllers/PayableBillsController.cs
+++ b/EvangelionERPV2.Web/Controllers/PayableBillsController.cs
@@ -1,0 +1,137 @@
+using System.Security.Claims;
+using AutoMapper;
+using EvangelionERPV2.BillsModule.Application.Interface;
+using EvangelionERPV2.Shared.DTOs;
+using EvangelionERPV2.Shared.Entities;
+using EvangelionERPV2.Shared.Exceptions;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Serilog;
+
+namespace EvangelionERPV2.Web.Controllers
+{
+    [Authorize]
+    [Route("api/v{version:apiVersion}/[controller]/[action]")]
+    [ApiVersion("1.0")]
+    public class PayableBillsController : Controller
+    {
+        private readonly IPayableBillService _payableBillService;
+        private readonly IMapper _mapper;
+
+        public PayableBillsController(IPayableBillService payableBillService, IMapper mapper)
+        {
+            _payableBillService = payableBillService;
+            _mapper = mapper;
+        }
+
+        [HttpGet("{pageNumber?}/{pageSize?}")]
+        public async Task<IActionResult> GetPayableBills(int? pageNumber = null, int? pageSize = null)
+        {
+            try
+            {
+                if (!TryGetEnterpriseId(out var enterpriseId))
+                    return Unauthorized();
+
+                var bills = await _payableBillService.GetByEnterpriseIdAsync(enterpriseId, pageNumber, pageSize);
+                return Ok(_mapper.Map<IEnumerable<PayableBillDTO>>(bills));
+            }
+            catch (Exception ex)
+            {
+                Log.Logger.Error("Error getting payable bills", ex);
+                return Problem(ex.Message);
+            }
+        }
+
+        [HttpGet("{id}")]
+        public async Task<IActionResult> GetPayableBill(Guid id)
+        {
+            try
+            {
+                if (!TryGetEnterpriseId(out var enterpriseId))
+                    return Unauthorized();
+
+                var bill = await _payableBillService.GetByIdAsync(id, enterpriseId);
+                if (bill == null)
+                    return NoContent();
+
+                return Ok(_mapper.Map<PayableBillDTO>(bill));
+            }
+            catch (Exception ex)
+            {
+                Log.Logger.Error($"Error getting payable bill {id}", ex);
+                return Problem(ex.Message);
+            }
+        }
+
+        [HttpPost]
+        public async Task<IActionResult> AddPayableBill([FromBody] PayableBill payableBill)
+        {
+            try
+            {
+                if (!TryGetEnterpriseId(out var enterpriseId))
+                    return Unauthorized();
+
+                payableBill.EnterpriseId = enterpriseId;
+                var created = await _payableBillService.CreateAsync(payableBill);
+                return Ok(_mapper.Map<PayableBillDTO>(created));
+            }
+            catch (Exception ex)
+            {
+                Log.Logger.Error("Error creating payable bill", ex);
+                return Problem(ex.Message);
+            }
+        }
+
+        [HttpPut]
+        public async Task<IActionResult> UpdatePayableBill([FromBody] PayableBill payableBill)
+        {
+            try
+            {
+                if (!TryGetEnterpriseId(out var enterpriseId))
+                    return Unauthorized();
+
+                var updated = await _payableBillService.UpdateAsync(payableBill, enterpriseId);
+                return Ok(_mapper.Map<PayableBillDTO>(updated));
+            }
+            catch (NotFoundDatabaseException ex)
+            {
+                Log.Logger.Error("Payable bill not found", ex);
+                return NoContent();
+            }
+            catch (Exception ex)
+            {
+                Log.Logger.Error($"Error updating payable bill {payableBill.Id}", ex);
+                return Problem(ex.Message);
+            }
+        }
+
+        [HttpDelete("{id}")]
+        public async Task<IActionResult> DeletePayableBill(Guid id)
+        {
+            try
+            {
+                if (!TryGetEnterpriseId(out var enterpriseId))
+                    return Unauthorized();
+
+                var deleted = await _payableBillService.DeleteAsync(id, enterpriseId);
+                return Ok(_mapper.Map<PayableBillDTO>(deleted));
+            }
+            catch (NotFoundDatabaseException ex)
+            {
+                Log.Logger.Error("Payable bill not found", ex);
+                return NoContent();
+            }
+            catch (Exception ex)
+            {
+                Log.Logger.Error($"Error deleting payable bill {id}", ex);
+                return Problem(ex.Message);
+            }
+        }
+
+        private bool TryGetEnterpriseId(out Guid enterpriseId)
+        {
+            var claimValue = User.FindFirst(ClaimTypes.GroupSid)?.Value;
+            return Guid.TryParse(claimValue, out enterpriseId) && enterpriseId != Guid.Empty;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `ICashFlowForecastService` and `CashFlowForecastService` to calculate 30/60/90-day projections
- include current balance, receivables from orders, and payables from manually created `PayableBill` records
- mark negative projected-balance days as risk days in daily forecast output
- add scenario simulation endpoint that requires at least two scenarios and returns each scenario impact on final projected balance
- persist each simulation execution in `ForecastSimulationLog` with enterprise, user, timestamp, scenario name, and inputs
- add unit tests for forecast math and scenario validation

## API
- `GET /api/v1/CashFlowForecast/GetForecast/{horizonInDays}/{currentBalance}`
- `POST /api/v1/CashFlowForecast/RunSimulation`

## Notes
- this branch is intended to be opened on top of `feature/40-Inteligent-cash-flow-forecast-bills-payable` (stacked PR), since forecast depends on payable bills.
- tests could not be executed in this environment because the `dotnet` CLI is unavailable.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994c5f1f5b08320bf4ff9d6110f7df8)